### PR TITLE
wav変換をファイルIOを用いない方法に変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,19 @@
 FROM python:3.9.4
 
-WORKDIR /app
-
-COPY . /app/
-
 RUN apt-get update
 RUN apt-get -y install open-jtalk open-jtalk-mecab-naist-jdic
+
+WORKDIR /tmp
 
 RUN git clone https://github.com/icn-lab/htsvoice-tohoku-f01.git
 
 RUN ln -s /var/lib/mecab/dic/open-jtalk/naist-jdic /usr/local/share/open_jtalk_dic
 
 RUN mkdir /usr/local/share/hts_voice
-RUN ln -s /app/htsvoice-tohoku-f01 /usr/local/share/hts_voice/htsvoice-tohoku-f01
+RUN ln -s /tmp/htsvoice-tohoku-f01 /usr/local/share/hts_voice/htsvoice-tohoku-f01
+
+WORKDIR /app
+COPY . /app/
 
 RUN pip install --upgrade pip
 RUN pip install --upgrade setuptools

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.9.4
+
+WORKDIR /app
+
+COPY . /app/
+
+RUN apt-get update
+RUN apt-get -y install open-jtalk open-jtalk-mecab-naist-jdic
+
+RUN git clone https://github.com/icn-lab/htsvoice-tohoku-f01.git
+
+RUN ln -s /var/lib/mecab/dic/open-jtalk/naist-jdic /usr/local/share/open_jtalk_dic
+
+RUN mkdir /usr/local/share/hts_voice
+RUN ln -s /app/htsvoice-tohoku-f01 /usr/local/share/hts_voice/htsvoice-tohoku-f01
+
+RUN pip install --upgrade pip
+RUN pip install --upgrade setuptools
+
+RUN pip install -r requirements.txt
+ENV FLASK_APP main
+
+CMD ["flask", "run", "--host", "0.0.0.0", "--port", "5000"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# OpenJWeb
+
+## Overview
+
+これは、[OpenJTalk](http://open-jtalk.sourceforge.net/)のWebAPIサーバープログラムです。
+
+## Description
+[OpenJTalk](http://open-jtalk.sourceforge.net/)の読み上げ機能を用いて、文章をwav音声に変換する、WebAPIサーバープログラムです。  
+
+
+## Requirement
+ - python3.9.4
+ - flask
+ - open-jtalk
+ - open-jtalk-mecab-naist-jdic
+
+## Usage
+### POST /
+#### Parameters
+|  Name  | Required |  Type  | Description |
+| ------ | -------- | ------ | ----------- |
+| `text` | required | string | 読み上げる文章 |
+
+## Install
+### Use DockerCompose
+1. `$ docker-compose up`  
+
+デフォルトでは、[HTS voice tohoku-f01](https://github.com/icn-lab/htsvoice-tohoku-f01.git)が音声として設定されます。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3'
+services:
+  app:
+    build: .
+    ports:
+     - "5000:5000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
-version: '3'
+version: "3"
 services:
   app:
     build: .
     ports:
-     - "5000:5000"
+      - "5100:5000"
+    volumes:
+      - "./:/app"

--- a/jtalk.py
+++ b/jtalk.py
@@ -5,28 +5,36 @@ from datetime import datetime
 
 pf = platform.system()
 
-def jtalk(t, server_id=None):
+
+def convert_to_wav(t: str, server_id=None):
     open_jtalk = ['open_jtalk']
-    filename = '{}.wav'.format(time.time())
     if pf == 'Darwin':
         mech = ['-x', '/usr/local/Cellar/open-jtalk/1.11/dic']
-        htsvoice = ['-m', '/usr/local/Cellar/open-jtalk/1.11/voice/htsvoice-tohoku-f01/tohoku-f01-neutral.htsvoice']
+        htsvoice = [
+            '-m', '/usr/local/Cellar/open-jtalk/1.11/voice/htsvoice-tohoku-f01/tohoku-f01-neutral.htsvoice']
     else:
         mech = ['-x', '/usr/local/share/open_jtalk_dic']
-        htsvoice = ['-m', '/usr/local/share/hts_voice/htsvoice-tohoku-f01/tohoku-f01-neutral.htsvoice']
-    
+        htsvoice = [
+            '-m', '/usr/local/share/hts_voice/htsvoice-tohoku-f01/tohoku-f01-neutral.htsvoice']
+
     speed = ['-r', '1.0']
-    outwav = ['-ow', '{}'.format(filename)]
+    outwav = ['-ow', '/dev/stdout']
     cmd = open_jtalk + mech + htsvoice + speed + outwav
-    c = subprocess.Popen(cmd, stdin=subprocess.PIPE)
-    c.communicate(t.encode())
-    c.wait()
-    return filename
+    c = subprocess.run(
+        cmd,
+        shell=False,
+        input=t.encode(),
+        stdout=subprocess.PIPE
+    )
+
+    return c.stdout
+
 
 def say_datetime():
     d = datetime.now()
     text = '%s月%s日、%s時%s分%s秒' % (d.month, d.day, d.hour, d.minute, d.second)
-    jtalk(text)
+    convert_to_wav(text)
+
 
 if __name__ == '__main__':
     say_datetime()

--- a/main.py
+++ b/main.py
@@ -1,28 +1,28 @@
+import io
 import os
 import json
-from flask import Flask, request, send_file
-from jtalk import jtalk
+from flask import Flask, render_template, request, send_file
+from flask.helpers import make_response
+from jtalk import convert_to_wav
 
 app = Flask(__name__)
 
-@app.route('/', methods=['POST'])
+
+@app.route('/', methods=['GET', 'POST'])
 def say():
+    if request.method == 'GET':
+        return render_template('index.html')
     data = request.data.decode('utf-8')
     jdata = json.loads(data)
-    read = jdata['text']
-    fname = jtalk(read)
-    fpath = './'+fname
-    return send_file(
-            fpath,
-            mimetype='audio/wav',
-            as_attachment=True,
-            attachment_filename='{}'.format(fname))
-
-@app.after_request
-def after_request(responce):
-    if responce.status_code == 200:
-        os.remove(responce.headers['Content-Disposition'][21:])
-    return responce
+    read = jdata.get('text')
+    if read == '':
+        return ('', 400)
+    out = convert_to_wav(read)
+    if out is None:
+        return ('', 400)
+    response = make_response(out)
+    response.headers.set('Content-Type', 'audio/wav')
+    return response
 
 
 if __name__ == '__main__':

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+  <!-- Google Fonts -->
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
+
+  <!-- CSS Reset -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.css">
+
+  <!-- Milligram CSS -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/milligram/1.4.1/milligram.css">
+
+  <!-- You should properly set the path from the main file. -->
+</head>
+
+<body>
+  <main>
+    <div class="container">
+      <h1>OpenJWeb Demo</h1>
+      <form>
+        <fieldset>
+          <label for="textField">Comment</label>
+          <textarea placeholder="nekochan..." id="textField"></textarea>
+          <input class="button-primary" id="submit" type="submit" value="Send">
+        </fieldset>
+      </form>
+      <audio id="player"></audio>
+    </div>
+  </main>
+  <script>
+    const $submit = document.getElementById("submit");
+    const $textField = document.getElementById("textField");
+    const $player = document.getElementById("player");
+
+    $submit.addEventListener("click", (e) => {
+      $submit.disabled = true;
+      (async () => {
+        try {
+          const resp = await fetch("/", { method: "POST", body: JSON.stringify({ text: $textField.value }) })
+          const blob = await resp.blob();
+          $player.src = URL.createObjectURL(blob);
+          $player.play();
+        } finally {
+          $submit.disabled = false;
+        }
+      })()
+      e.preventDefault()
+    })
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
# 変更点
 - Dockerfile追加
 - docker-composeファイル追加
 - README.md作成
 - open_jtalkの出力先を、ファイルから`stdout`に変更
   - ファイルIOを介さないことで、動作速度の向上が望める
![image](https://user-images.githubusercontent.com/11145973/130376687-797292a0-87ac-450f-b2ba-d025c4574904.png)
   - 橙が`stdout`版、青が`ファイルIO`版である。
   - およそ50ms程度の改善が見られる
 - index.htmlの追加
 - `text`が空の時、400番を返すようにした